### PR TITLE
Prevent ctrl-0 from switching to the 9th tab

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -7,5 +7,6 @@
 	{ "keys": ["ctrl+6"], "command": "goto_tab", "args": {"tab":"6"} },
 	{ "keys": ["ctrl+7"], "command": "goto_tab", "args": {"tab":"7"} },
 	{ "keys": ["ctrl+8"], "command": "goto_tab", "args": {"tab":"8"} },
-	{ "keys": ["ctrl+9"], "command": "goto_tab", "args": {"tab":"last"} }
+	{ "keys": ["ctrl+9"], "command": "goto_tab", "args": {"tab":"last"} },
+	{ "keys": ["ctrl+0"], "command": "unbound" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -7,5 +7,6 @@
 	{ "keys": ["super+6"], "command": "goto_tab", "args": {"tab":"6"} },
 	{ "keys": ["super+7"], "command": "goto_tab", "args": {"tab":"7"} },
 	{ "keys": ["super+8"], "command": "goto_tab", "args": {"tab":"8"} },
-	{ "keys": ["super+9"], "command": "goto_tab", "args": {"tab":"last"} }
+	{ "keys": ["super+9"], "command": "goto_tab", "args": {"tab":"last"} },
+	{ "keys": ["super+0"], "command": "unbound" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -7,5 +7,6 @@
 	{ "keys": ["ctrl+6"], "command": "goto_tab", "args": {"tab":"6"} },
 	{ "keys": ["ctrl+7"], "command": "goto_tab", "args": {"tab":"7"} },
 	{ "keys": ["ctrl+8"], "command": "goto_tab", "args": {"tab":"8"} },
-	{ "keys": ["ctrl+9"], "command": "goto_tab", "args": {"tab":"last"} }
+	{ "keys": ["ctrl+9"], "command": "goto_tab", "args": {"tab":"last"} },
+	{ "keys": ["ctrl+0"], "command": "unbound" }
 ]


### PR DESCRIPTION
I'm a huge fan of ctrl-9, but sometimes accidentally hit ctrl-0. This pull request unsets the ctrl-0 keybinding on all platforms.
