### PR TITLE
Revert "Prevent ctrl-0 from switching to the 9th tab"

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -7,6 +7,5 @@
 	{ "keys": ["ctrl+6"], "command": "goto_tab", "args": {"tab":"6"} },
 	{ "keys": ["ctrl+7"], "command": "goto_tab", "args": {"tab":"7"} },
 	{ "keys": ["ctrl+8"], "command": "goto_tab", "args": {"tab":"8"} },
-	{ "keys": ["ctrl+9"], "command": "goto_tab", "args": {"tab":"last"} },
-	{ "keys": ["ctrl+0"], "command": "unbound" }
+	{ "keys": ["ctrl+9"], "command": "goto_tab", "args": {"tab":"last"} }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -7,6 +7,5 @@
 	{ "keys": ["super+6"], "command": "goto_tab", "args": {"tab":"6"} },
 	{ "keys": ["super+7"], "command": "goto_tab", "args": {"tab":"7"} },
 	{ "keys": ["super+8"], "command": "goto_tab", "args": {"tab":"8"} },
-	{ "keys": ["super+9"], "command": "goto_tab", "args": {"tab":"last"} },
-	{ "keys": ["super+0"], "command": "unbound" }
+	{ "keys": ["super+9"], "command": "goto_tab", "args": {"tab":"last"} }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -7,6 +7,5 @@
 	{ "keys": ["ctrl+6"], "command": "goto_tab", "args": {"tab":"6"} },
 	{ "keys": ["ctrl+7"], "command": "goto_tab", "args": {"tab":"7"} },
 	{ "keys": ["ctrl+8"], "command": "goto_tab", "args": {"tab":"8"} },
-	{ "keys": ["ctrl+9"], "command": "goto_tab", "args": {"tab":"last"} },
-	{ "keys": ["ctrl+0"], "command": "unbound" }
+	{ "keys": ["ctrl+9"], "command": "goto_tab", "args": {"tab":"last"} }
 ]


### PR DESCRIPTION
Reverts SublimeText/GotoTab#3.

See [discussion](https://github.com/SublimeText/GotoTab/pull/3#issuecomment-249899807) about this pull-request.

Thanks.
